### PR TITLE
Install the `plone.app.layout` default profile 

### DIFF
--- a/news/+71bf1a52.feature.md
+++ b/news/+71bf1a52.feature.md
@@ -1,0 +1,1 @@
+Install the `plone.app.layout` default profile when creating a site using the classic distribution.  @mauritsvanrees

--- a/setup.py
+++ b/setup.py
@@ -29,6 +29,7 @@ setup(
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
         "Programming Language :: Python :: 3.12",
+        "Programming Language :: Python :: 3.13",
         "Programming Language :: Python",
     ],
     keywords="Python Plone CMS Distribution",
@@ -46,6 +47,7 @@ setup(
     install_requires=[
         "plone.distribution",
         "plone.base",
+        "plone.app.layout",
         "Zope",
     ],
     extras_require={

--- a/src/plone/classicui/dependencies.zcml
+++ b/src/plone/classicui/dependencies.zcml
@@ -2,5 +2,6 @@
 
   <include package="Products.CMFPlone" />
   <include package="plone.distribution" />
+  <include package="plone.app.layout" />
 
 </configure>

--- a/src/plone/classicui/distributions/classic/profiles.json
+++ b/src/plone/classicui/distributions/classic/profiles.json
@@ -1,6 +1,7 @@
 {
   "base": [
     "plone.app.contenttypes:default",
+    "plone.app.layout:default",
     "plonetheme.barceloneta:default"
   ],
   "content": [


### PR DESCRIPTION
Refs https://github.com/plone/plone.classicui/issues/23

This benefits from https://github.com/plone/plone.classicui/issues/23, otherwise the `plone.app.layout` add-on is still not marked as installed in the control panel.